### PR TITLE
Add callback to write method.  (Fix #5)

### DIFF
--- a/lib/todo.js
+++ b/lib/todo.js
@@ -127,7 +127,7 @@ Todo.prototype.load = function load (filepath) {
 };
 
 Todo.prototype.write = function write (filepath) {
-  fs.writeFile(filepath || this._options.output, this.md.join('\n'));
+  fs.writeFile(filepath || this._options.output, this.md.join('\n'), (err) => {if(err) console.log('error', err)});
 
   return this;
 };


### PR DESCRIPTION
Fixes #5.

Error code `TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined` originates from the lack of this parameter.